### PR TITLE
Rename Metadata to ObjectMeta, configure routes for address and connection detail page

### DIFF
--- a/console/console-init/ui/src/AppRoutes.tsx
+++ b/console/console-init/ui/src/AppRoutes.tsx
@@ -9,24 +9,26 @@ const getConnectionDetail = () => import("./Pages/ConnectionDetailPage");
 
 export const AppRoutes = () => (
   <SwitchWith404>
-    <Redirect path="/" to="/address-spaces" exact={true} />
+    <Redirect path="/" to="/address_spaces" exact={true} />
     <LazyRoute
-      path="/address-spaces"
+      path="/address_spaces"
       exact={true}
       getComponent={getAddressSpaceListPage}
     />
     <LazyRoute
-      path="/address-space/:id/:subList"
+      path="/address_space/name=:name&namespace=:namespace/:subList"
       exact={true}
       getComponent={getAddressSpaceDetail}
     />
     <LazyRoute
-      path="/address-space/:id/address/:id"
+      path="/address_space/name=:name&namespace=:namespace/address/name=:addressname&namespace=:addressnamespace"
       getComponent={getAddressDetail}
+      exact={true}
     />
     <LazyRoute
-      path="/address-space/:id/connection/:id"
+      path="/address_space/name=:name&namespace=:namespace/connection/name=:conectionname&namespace=:connectionnamespace"
       getComponent={getConnectionDetail}
+      exact={true}
     />
   </SwitchWith404>
 );

--- a/console/console-init/ui/src/AppRoutes.tsx
+++ b/console/console-init/ui/src/AppRoutes.tsx
@@ -16,17 +16,17 @@ export const AppRoutes = () => (
       getComponent={getAddressSpaceListPage}
     />
     <LazyRoute
-      path="/address-space/:name/:namespace/:subList"
+      path="/address-space/:namespace/:name/:subList"
       exact={true}
       getComponent={getAddressSpaceDetail}
     />
     <LazyRoute
-      path="/address-space/:name/:namespace/address/:addressname/:addressnamespace"
+      path="/address-space/:namespace/:name/address/:addressname"
       getComponent={getAddressDetail}
       exact={true}
     />
     <LazyRoute
-      path="/address-space/:name/:namespace/connection/:connectionname/:connectionnamespace"
+      path="/address-space/:namespace/:name/connection/:connectionname"
       getComponent={getConnectionDetail}
       exact={true}
     />

--- a/console/console-init/ui/src/AppRoutes.tsx
+++ b/console/console-init/ui/src/AppRoutes.tsx
@@ -9,24 +9,24 @@ const getConnectionDetail = () => import("./Pages/ConnectionDetailPage");
 
 export const AppRoutes = () => (
   <SwitchWith404>
-    <Redirect path="/" to="/address_spaces" exact={true} />
+    <Redirect path="/" to="/address-spaces" exact={true} />
     <LazyRoute
-      path="/address_spaces"
+      path="/address-spaces"
       exact={true}
       getComponent={getAddressSpaceListPage}
     />
     <LazyRoute
-      path="/address_space/name=:name&namespace=:namespace/:subList"
+      path="/address-space/:name/:namespace/:subList"
       exact={true}
       getComponent={getAddressSpaceDetail}
     />
     <LazyRoute
-      path="/address_space/name=:name&namespace=:namespace/address/name=:addressname&namespace=:addressnamespace"
+      path="/address-space/:name/:namespace/address/:addressname/:addressnamespace"
       getComponent={getAddressDetail}
       exact={true}
     />
     <LazyRoute
-      path="/address_space/name=:name&namespace=:namespace/connection/name=:conectionname&namespace=:connectionnamespace"
+      path="/address-space/:name/:namespace/connection/:connectionname/:connectionnamespace"
       getComponent={getConnectionDetail}
       exact={true}
     />

--- a/console/console-init/ui/src/Components/AddressSpace/AddressList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpace/AddressList.tsx
@@ -60,7 +60,7 @@ export const AddressList: React.FunctionComponent<IAddressListProps> = ({
   const toTableCells = (row: IAddress) => {
     const tableRow: IRowData = {
       cells: [
-        { title: <Link to={`address/name=${row.name}&namespace=${row.namespace}`}>{row.name}</Link> },
+        { title: <Link to={`address/${row.name}/${row.namespace}`}>{row.name}</Link> },
         row.type,
         row.plan,
         {

--- a/console/console-init/ui/src/Components/AddressSpace/AddressList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpace/AddressList.tsx
@@ -60,7 +60,7 @@ export const AddressList: React.FunctionComponent<IAddressListProps> = ({
   const toTableCells = (row: IAddress) => {
     const tableRow: IRowData = {
       cells: [
-        { title: <Link to={`address/${row.name}/${row.namespace}`}>{row.name}</Link> },
+        { title: <Link to={`address/${row.name}`}>{row.name}</Link> },
         row.type,
         row.plan,
         {

--- a/console/console-init/ui/src/Components/AddressSpace/AddressList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpace/AddressList.tsx
@@ -8,9 +8,11 @@ import {
 } from "@patternfly/react-table";
 import { Link } from "react-router-dom";
 import { Messages } from "../Messages";
+import { AddressListFilterWithPagination } from "./AddressListFilterWithPaginationHeader";
 
 export interface IAddress {
   name: string;
+  namespace:string;
   type: string;
   plan: string;
   messagesIn: number;
@@ -58,7 +60,7 @@ export const AddressList: React.FunctionComponent<IAddressListProps> = ({
   const toTableCells = (row: IAddress) => {
     const tableRow: IRowData = {
       cells: [
-        { title: <Link to="#">{row.name}</Link> },
+        { title: <Link to={`address/name=${row.name}&namespace=${row.namespace}`}>{row.name}</Link> },
         row.type,
         row.plan,
         {

--- a/console/console-init/ui/src/Components/AddressSpace/AddressListFilterWithPaginationHeader.tsx
+++ b/console/console-init/ui/src/Components/AddressSpace/AddressListFilterWithPaginationHeader.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import {
+  Grid,
+  GridItem,
+  InputGroup,
+  Dropdown,
+  DropdownToggle,
+  TextInput,
+  Button,
+  ButtonVariant,
+  DropdownPosition,
+  KebabToggle,
+  Pagination,
+  PageSection,
+  PageSectionVariants
+} from "@patternfly/react-core";
+import { SearchIcon } from "@patternfly/react-icons";
+import { AddressListFilter } from "./AddressListFilter";
+
+export const AddressListFilterWithPagination: React.FunctionComponent<
+  any
+> = () => {
+  const [filter, setFilter] = React.useState("Name");
+  const onFilterSelect = (item: any) => {
+    console.log(item);
+  };
+  return (
+      <InputGroup>
+        <AddressListFilter
+          onSearch={() => {
+            console.log("on Search");
+          }}
+          onFilterSelect={onFilterSelect}
+          filterValue={filter}
+          onTypeSelect={() => {}}
+          typeValue={"Small"}
+          onStatusSelect={() => {}}
+          statusValue={"Active"}
+        />
+        <Button variant="primary">Create address</Button>
+        <Dropdown
+          isPlain
+          position={DropdownPosition.right}
+          isOpen={false}
+          onSelect={() => {}}
+          toggle={<KebabToggle onToggle={() => {}} />}
+          dropdownItems={[]}
+        />
+      </InputGroup>
+  );
+};

--- a/console/console-init/ui/src/Components/AddressSpace/AddressSpaceNavigation.tsx
+++ b/console/console-init/ui/src/Components/AddressSpace/AddressSpaceNavigation.tsx
@@ -26,7 +26,7 @@ export const AddressSpaceNavigation: React.FunctionComponent<
             key="addresses"
             itemId="addresses"
             isActive={active==="addresses"}>
-            <NavLink to={`/address_space/name=${name}&namespace=${namespace}/addresses`} >
+            <NavLink to={`/address-space/${name}/${namespace}/addresses`} >
               Addresses
             </NavLink>
           </NavItem>
@@ -34,7 +34,7 @@ export const AddressSpaceNavigation: React.FunctionComponent<
             key="connections"
             itemId="connections"
             isActive={active==="connections"}>
-            <NavLink to={`/address_space/name=${name}&namespace=${namespace}/connections`}>
+            <NavLink to={`/address-space/${name}/${namespace}/connections`}>
               Connections
             </NavLink>
           </NavItem>

--- a/console/console-init/ui/src/Components/AddressSpace/AddressSpaceNavigation.tsx
+++ b/console/console-init/ui/src/Components/AddressSpace/AddressSpaceNavigation.tsx
@@ -5,31 +5,36 @@ import {
   NavVariants,
   NavItem
 } from "@patternfly/react-core";
-import { NavLink } from "react-router-dom";
+import { NavLink, useParams } from "react-router-dom";
 
 export interface AddressSpaceNavigationProps {
   activeItem: string;
-  onSelect: (item: any) => void;
+  name?:string;
+  namespace?:string;
 }
 export const AddressSpaceNavigation: React.FunctionComponent<
   AddressSpaceNavigationProps
-> = ({ activeItem, onSelect }) => {
+> = ({ activeItem , name, namespace }) => {
+  const [active,setActive] = React.useState(activeItem);
+  const onSelect1 = (result:any)=>{
+    setActive(result.itemId)
+  }
   return (
-      <Nav onSelect={onSelect}>
+      <Nav onSelect={onSelect1}>
         <NavList variant={NavVariants.tertiary}>
           <NavItem
             key="addresses"
             itemId="addresses"
-            isActive={activeItem === "addresses"}>
-            <NavLink to={"/address-space/456/addresses"} >
+            isActive={active==="addresses"}>
+            <NavLink to={`/address_space/name=${name}&namespace=${namespace}/addresses`} >
               Addresses
             </NavLink>
           </NavItem>
           <NavItem
             key="connections"
             itemId="connections"
-            isActive={activeItem === "connections"}>
-            <NavLink to={"/address-space/456/connections"}>
+            isActive={active==="connections"}>
+            <NavLink to={`/address_space/name=${name}&namespace=${namespace}/connections`}>
               Connections
             </NavLink>
           </NavItem>

--- a/console/console-init/ui/src/Components/AddressSpace/AddressSpaceNavigation.tsx
+++ b/console/console-init/ui/src/Components/AddressSpace/AddressSpaceNavigation.tsx
@@ -9,12 +9,10 @@ import { NavLink, useParams } from "react-router-dom";
 
 export interface AddressSpaceNavigationProps {
   activeItem: string;
-  name?:string;
-  namespace?:string;
 }
 export const AddressSpaceNavigation: React.FunctionComponent<
   AddressSpaceNavigationProps
-> = ({ activeItem , name, namespace }) => {
+> = ({ activeItem }) => {
   const [active,setActive] = React.useState(activeItem);
   const onSelect1 = (result:any)=>{
     setActive(result.itemId)
@@ -26,7 +24,7 @@ export const AddressSpaceNavigation: React.FunctionComponent<
             key="addresses"
             itemId="addresses"
             isActive={active==="addresses"}>
-            <NavLink to={`/address-space/${name}/${namespace}/addresses`} >
+            <NavLink to={`addresses`} >
               Addresses
             </NavLink>
           </NavItem>
@@ -34,7 +32,7 @@ export const AddressSpaceNavigation: React.FunctionComponent<
             key="connections"
             itemId="connections"
             isActive={active==="connections"}>
-            <NavLink to={`/address-space/${name}/${namespace}/connections`}>
+            <NavLink to={`connections`}>
               Connections
             </NavLink>
           </NavItem>

--- a/console/console-init/ui/src/Components/AddressSpace/ConnectionList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpace/ConnectionList.tsx
@@ -30,7 +30,7 @@ export const ConnectionList: React.FunctionComponent<IConnectionListProps> = ({
   const toTableCells = (row: IConnection) => {
     const tableRow: IRowData = {
       cells: [
-        { title: <Link to={`connection/name=${row.hostname}&namespace=${row.containerId}`}>{row.hostname}</Link> },
+        { title: <Link to={`connection/${row.hostname}/${row.containerId}`}>{row.hostname}</Link> },
         row.containerId,
         { title: <ConnectionProtocolFormat protocol={row.protocol} /> },
         row.messagesIn,

--- a/console/console-init/ui/src/Components/AddressSpace/ConnectionList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpace/ConnectionList.tsx
@@ -6,7 +6,7 @@ import {
   TableBody,
   IRowData
 } from "@patternfly/react-table";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { ConnectionProtocolFormat } from "../Common/ConnectionListFormatter";
 
 interface IConnectionListProps {
@@ -30,7 +30,7 @@ export const ConnectionList: React.FunctionComponent<IConnectionListProps> = ({
   const toTableCells = (row: IConnection) => {
     const tableRow: IRowData = {
       cells: [
-        { title: <Link to="#">{row.hostname}</Link> },
+        { title: <Link to={`connection/name=${row.hostname}&namespace=${row.containerId}`}>{row.hostname}</Link> },
         row.containerId,
         { title: <ConnectionProtocolFormat protocol={row.protocol} /> },
         row.messagesIn,
@@ -44,7 +44,7 @@ export const ConnectionList: React.FunctionComponent<IConnectionListProps> = ({
   };
   const tableRows = rows.map(toTableCells);
   const tableColumns = [
-    "Hostname",
+    {title:"Hostname",dataLabel:"host"},
     "Container ID",
     "Protocol",
     "Messages In",
@@ -54,7 +54,13 @@ export const ConnectionList: React.FunctionComponent<IConnectionListProps> = ({
   ];
 
   return (
-    <Table variant={TableVariant.compact} cells={tableColumns} rows={tableRows}>
+    <Table
+
+      variant={TableVariant.compact}
+      cells={tableColumns}
+      rows={tableRows}
+      aria-label="connection list"
+    >
       <TableHeader />
       <TableBody />
     </Table>

--- a/console/console-init/ui/src/Components/AddressSpace/ConnectionList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpace/ConnectionList.tsx
@@ -30,7 +30,7 @@ export const ConnectionList: React.FunctionComponent<IConnectionListProps> = ({
   const toTableCells = (row: IConnection) => {
     const tableRow: IRowData = {
       cells: [
-        { title: <Link to={`connection/${row.hostname}/${row.containerId}`}>{row.hostname}</Link> },
+        { title: <Link to={`connection/${row.hostname}`}>{row.hostname}</Link> },
         row.containerId,
         { title: <ConnectionProtocolFormat protocol={row.protocol} /> },
         row.messagesIn,

--- a/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceList.tsx
@@ -63,7 +63,7 @@ export const AddressSpaceLsit: React.FunctionComponent<IAddressListProps> = ({
           header: "name",
           title: (
             <>
-              <Link to={`address-space/${row.name}/addresses`}>{row.name}</Link>
+              <Link to={`address_space/name=${row.name}&namespace=${row.nameSpace}/addresses`}>{row.name}</Link>
               <br />
               {row.nameSpace}
             </>

--- a/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceList.tsx
@@ -63,7 +63,7 @@ export const AddressSpaceLsit: React.FunctionComponent<IAddressListProps> = ({
           header: "name",
           title: (
             <>
-              <Link to={`address_space/name=${row.name}&namespace=${row.nameSpace}/addresses`}>{row.name}</Link>
+              <Link to={`address-space/${row.name}/${row.nameSpace}/addresses`}>{row.name}</Link>
               <br />
               {row.nameSpace}
             </>

--- a/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceList.tsx
@@ -63,7 +63,7 @@ export const AddressSpaceLsit: React.FunctionComponent<IAddressListProps> = ({
           header: "name",
           title: (
             <>
-              <Link to={`address-space/${row.name}/${row.nameSpace}/addresses`}>{row.name}</Link>
+              <Link to={`address-space/${row.nameSpace}/${row.name}/addresses`}>{row.name}</Link>
               <br />
               {row.nameSpace}
             </>

--- a/console/console-init/ui/src/Components/Common/FilterDropdown.tsx
+++ b/console/console-init/ui/src/Components/Common/FilterDropdown.tsx
@@ -19,10 +19,14 @@ export const FilterDropdown: React.FunctionComponent<IDropdown> = ({
   options
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
+  const onSelectFilter =(item:any)=>{
+    onSelect(item);
+    setIsOpen(!isOpen);
+  }
   return (
     <Dropdown
       position="left"
-      onSelect={onSelect}
+      onSelect={onSelectFilter}
       isOpen={isOpen}
       toggle={
         <DropdownToggle onToggle={setIsOpen}>

--- a/console/console-init/ui/src/Components/ConnectionDetail/ConnectionDetail.tsx
+++ b/console/console-init/ui/src/Components/ConnectionDetail/ConnectionDetail.tsx
@@ -40,7 +40,7 @@ export const ConnectionDetail: React.FunctionComponent<
           <b>Product</b> {product}
         </FlexItem>
         <FlexItem>
-          <b>Version</b>
+          <b>Version </b>
           {version} SNAPSHOT
         </FlexItem>
       </Flex>

--- a/console/console-init/ui/src/Components/LinkList.tsx
+++ b/console/console-init/ui/src/Components/LinkList.tsx
@@ -21,7 +21,7 @@ export interface ILink {
   modified: number;
   presettled: number;
   undelivered: number;
-  status: "creating" | "deleting" | "running";
+  status?: "creating" | "deleting" | "running";
 }
 
 export const LinkList: React.FunctionComponent<ILinkListProps> = ({ rows }) => {
@@ -56,7 +56,7 @@ export const LinkList: React.FunctionComponent<ILinkListProps> = ({ rows }) => {
   ];
 
   return (
-    <Table variant={TableVariant.compact} cells={tableColumns} rows={tableRows}>
+    <Table variant={TableVariant.compact} cells={tableColumns} rows={tableRows} aria-label="links list">
       <TableHeader />
       <TableBody />
     </Table>

--- a/console/console-init/ui/src/Components/Messages.tsx
+++ b/console/console-init/ui/src/Components/Messages.tsx
@@ -5,7 +5,7 @@ import {
 } from "@patternfly/react-icons";
 
 interface IMessagesProps {
-  count: number;
+  count: any;
   column: string;
   status: string;
 }

--- a/console/console-init/ui/src/Pages/AddressDetailPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressDetailPage.tsx
@@ -7,67 +7,10 @@ import {
 } from 'src/Components/AddressSpace/ConnectionList';
 
 export default function AddressDetailPage() {
-  const props = {
-    hostname: '1.219.2.1.33904',
-    containerId: 'myapp1',
-    protocol: 'AMQP',
-    product: 'QpidJMS',
-    version: '0.31.0',
-    platform: '0.8.0_152.25.125.b16',
-    os: 'Mac OS X 10.12.6,x86_64',
-    messagesIn: 0,
-    messagesOut: 0,
-  };
-  const rows: IConnection[] = [
-    {
-      hostname: 'foo',
-      containerId: '123',
-      protocol: 'AMQP',
-      messagesIn: 123,
-      messagesOut: 123,
-      senders: 123,
-      receivers: 123,
-      status: 'running',
-    },
-    {
-      hostname: 'foo',
-      containerId: '123',
-      protocol: 'AMQP',
-      messagesIn: 123,
-      messagesOut: 123,
-      senders: 123,
-      receivers: 123,
-      status: 'running',
-    },
-    {
-      hostname: 'foo',
-      containerId: '123',
-      protocol: 'AMQP',
-      messagesIn: 123,
-      messagesOut: 123,
-      senders: 123,
-      receivers: 123,
-      status: 'running',
-    },
-  ];
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
         <h1>Address Detial Page</h1>
-      </PageSection>
-      <ConnectionDetailHeader
-        hostname={props.hostname}
-        containerId={props.containerId}
-        protocol={props.protocol}
-        product={props.product}
-        version={props.version}
-        platform={props.platform}
-        os={props.os}
-        messagesIn={props.messagesIn}
-        messagesOut={props.messagesOut}
-      />
-      <PageSection>
-        <ConnectionList rows={rows} />
       </PageSection>
     </>
   );

--- a/console/console-init/ui/src/Pages/AddressSpaceDetailPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetailPage.tsx
@@ -115,12 +115,12 @@ export default function AddressSpaceDetailPage() {
         <SwitchWith404>
           <Redirect path="/" to="/address-spaces" exact={true} />
           <LazyRoute
-            path="/address_space/name=:name&namespace=:namespace/addresses"
+            path="/address-space/:name/:namespace/addresses"
             getComponent={getAddressesList}
             exact={true}
           />
           <LazyRoute
-            path="/address_space/name=:name&namespace=:namespace/connections"
+            path="/address-space/:name/:namespace/connections"
             getComponent={getConnectionsList}
             exact={true}
           />

--- a/console/console-init/ui/src/Pages/AddressSpaceDetailPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetailPage.tsx
@@ -107,20 +107,18 @@ export default function AddressSpaceDetailPage() {
         <AddressSpaceHeader {...addressSpaceDetails} />
         <AddressSpaceNavigation
           activeItem={subList || "addresses"}
-          name={name}
-          namespace={namespace}
         ></AddressSpaceNavigation>
       </PageSection>
       <PageSection>
         <SwitchWith404>
           <Redirect path="/" to="/address-spaces" exact={true} />
           <LazyRoute
-            path="/address-space/:name/:namespace/addresses"
+            path="/address-space/:namespace/:name/addresses"
             getComponent={getAddressesList}
             exact={true}
           />
           <LazyRoute
-            path="/address-space/:name/:namespace/connections"
+            path="/address-space/:namespace/:name/connections"
             getComponent={getConnectionsList}
             exact={true}
           />

--- a/console/console-init/ui/src/Pages/AddressSpaceListPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceListPage.tsx
@@ -18,7 +18,7 @@ const ALL_ADDRESS_SPACES = gql`
     addressSpaces {
       Total
       AddressSpaces {
-        Metadata {
+        ObjectMeta {
           Namespace
           Name
           CreationTimestamp
@@ -43,7 +43,7 @@ interface IAddressSpacesResponse {
   addressSpaces: {
     Total: number;
     AddressSpaces: Array<{
-      Metadata: {
+      ObjectMeta: {
         Name: string;
         Namespace: string;
         CreationTimestamp: string;
@@ -112,9 +112,9 @@ function AddressSpaceListFunc() {
     addressSpaces: { Total: 0, AddressSpaces: [] }
   };
   const addressSpacesList = addressSpaces.AddressSpaces.map(addSpace => ({
-    name: addSpace.Metadata.Name,
-    nameSpace: addSpace.Metadata.Namespace,
-    creationTimestamp: addSpace.Metadata.CreationTimestamp,
+    name: addSpace.ObjectMeta.Name,
+    nameSpace: addSpace.ObjectMeta.Namespace,
+    creationTimestamp: addSpace.ObjectMeta.CreationTimestamp,
     type: addSpace.Spec.Type,
     displayName: addSpace.Spec.Plan.Spec.DisplayName,
     isReady: addSpace.Status.IsReady

--- a/console/console-init/ui/src/Pages/AddressesListPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressesListPage.tsx
@@ -1,25 +1,43 @@
 import * as React from "react";
-import { Link, useLocation, useHistory } from "react-router-dom";
-import { PageSection, PageSectionVariants } from "@patternfly/react-core";
+import { Link, useLocation, useHistory, useParams } from "react-router-dom";
+import {
+  PageSection,
+  PageSectionVariants,
+  Pagination,
+  GridItem,
+  Grid
+} from "@patternfly/react-core";
 import gql from "graphql-tag";
 import { useQuery } from "@apollo/react-hooks";
 import { useDocumentTitle, useA11yRouteChange, Loading } from "use-patternfly";
 import { IAddress, AddressList } from "src/Components/AddressSpace/AddressList";
 import { EmptyAddress } from "src/Components/Common/EmptyAddress";
+import { AddressListFilterWithPagination } from "src/Components/AddressSpace/AddressListFilterWithPaginationHeader";
+import { StyleSheet } from "@patternfly/react-styles";
 
-const ALL_ADDRESS_FOR_ADDRESS_SPACE = gql`
+const styles = StyleSheet.create({
+  header_bottom_border : { 
+    borderBottom:"1px solid black"
+  }
+})
+const retrun_ALL_ADDRESS_FOR_ADDRESS_SPACE = (
+  name?: string,
+  namespace?: string
+) => {
+  const ALL_ADDRESS_FOR_ADDRESS_SPACE = gql`
   query all_addresses_for_addressspace_view {
     addresses(
-      filter: "\`$.Spec.AddressSpace\` = 'jupiter_as1' AND \`$.Metadata.Namespace\` = 'app1_ns'"
+      filter: "\`$.Spec.AddressSpace\` = '${name}' AND \`$.ObjectMeta.Namespace\` = '${namespace}'"
     ) {
       Total
       Addresses {
-        Metadata {
+        ObjectMeta {
           Namespace
           Name
         }
         Spec {
           Address
+          Type
           Plan {
             Spec {
               DisplayName
@@ -40,17 +58,20 @@ const ALL_ADDRESS_FOR_ADDRESS_SPACE = gql`
     }
   }
 `;
+  return ALL_ADDRESS_FOR_ADDRESS_SPACE;
+};
 
 interface IAddressResponse {
   addresses: {
     Total: number;
     Addresses: Array<{
-      Metadata: {
+      ObjectMeta: {
         Namespace: string;
         Name: string;
       };
       Spec: {
         Address: string;
+        Type:string;
         Plan: {
           Spec: {
             DisplayName: string;
@@ -71,7 +92,15 @@ interface IAddressResponse {
   };
 }
 
+export interface IMetrics {
+  Name: string;
+  Type: string;
+  Value: number;
+  Units: string;
+}
+
 function AddressesListFunction() {
+  const { name, namespace } = useParams();
   useDocumentTitle("Addressses List");
   useA11yRouteChange();
   const location = useLocation();
@@ -81,7 +110,7 @@ function AddressesListFunction() {
   const perPage = parseInt(searchParams.get("perPage") || "", 10) || 10;
 
   const { loading, data } = useQuery<IAddressResponse>(
-    ALL_ADDRESS_FOR_ADDRESS_SPACE,
+    retrun_ALL_ADDRESS_FOR_ADDRESS_SPACE(name, namespace),
     { pollInterval: 5000 }
   );
 
@@ -112,48 +141,86 @@ function AddressesListFunction() {
     },
     [setSearchParam, history, searchParams]
   );
-  if (loading) return <Loading />
-//   console.log(data);
+  if (loading) return <Loading />;
+    console.log(data);
   const { addresses } = data || {
     addresses: { Total: 0, Addresses: [] }
   };
-//   addresses.Total=0;
+  const getFilteredValue = (object: IMetrics[], value: string) => {
+    const filtered = object.filter(obj => obj.Name === value);
+    if (filtered.length > 0) {
+      return filtered[0].Value;
+    }
+    return 0;
+  };
+
+  //   addresses.Total=0;
   const addressesList: IAddress[] = addresses.Addresses.map(address => ({
-    name: address.Metadata.Name,
-    type: address.Metadata.Namespace,
+    name: address.ObjectMeta.Name,
+    namespace:address.ObjectMeta.Namespace,
+    type: address.Spec.Type,
     plan: address.Spec.Plan.Spec.DisplayName,
-    messagesIn: address.Metrics.filter(metric => {
-      return "enmasse_messages_in";
-    })[0].Value,
-    messagesOut: address.Metrics.filter(metric => {
-      return "enmasse_messages_out";
-    })[0].Value,
-    storedMessages: address.Metrics.filter(metric => {
-      return "enmasse_messages_stored";
-    })[0].Value,
-    senders: address.Metrics.filter(metric => {
-      return "enmasse-senders";
-    })[0].Value,
-    receivers: address.Metrics.filter(metric => {
-      return "enmasse-receivers";
-    })[0].Value,
-    shards: 1,
+    messagesIn: getFilteredValue(address.Metrics, "enmasse_messages_in"),
+    messagesOut: getFilteredValue(address.Metrics, "enmasse_messages_out"),
+    storedMessages: getFilteredValue(
+      address.Metrics,
+      "enmasse_messages_stored"
+    ),
+    senders: getFilteredValue(address.Metrics, "enmasse-senders"),
+    receivers: getFilteredValue(address.Metrics, "enmasse-receivers"),
+    shards: getFilteredValue(address.Metrics, "enmasse-shards"),
     status: address.Status.IsReady ? "running" : "creating"
   }));
-  console.log(addresses);
-  if (addresses.Total === 0) return <EmptyAddress />;
-  else
-    return (
-      <AddressList
-        rows={addressesList}
-        onEdit={data => {
-          console.log("on Edit", data);
-        }}
-        onDelete={() => {
-          console.log("on Delete");
-        }}
-      />
-    );
+  // console.log(addresses);
+  return (
+    <PageSection variant={PageSectionVariants.light}>
+      <Grid>
+        <GridItem span={6}>
+          <AddressListFilterWithPagination />
+        </GridItem>
+        <GridItem span={6}>
+          {addresses.Total === 0 ? (
+            ""
+          ) : (
+            <Pagination
+              itemCount={523}
+              perPage={10}
+              page={1}
+              onSetPage={() => {}}
+              widgetId="pagination-options-menu-top"
+              onPerPageSelect={() => {}}
+            />
+          )}
+        </GridItem>
+      </Grid>
+      {addresses.Total === 0 ? (
+        <EmptyAddress />
+      ) : (
+        <AddressList
+          rows={addressesList}
+          onEdit={data => {
+            console.log("on Edit", data);
+          }}
+          onDelete={() => {
+            console.log("on Delete");
+          }}
+        />
+      )}
+
+      {addresses.Total === 0 ? (
+        ""
+      ) : (
+        <Pagination
+          itemCount={523}
+          perPage={10}
+          page={1}
+          onSetPage={() => {}}
+          widgetId="pagination-options-menu-top"
+          onPerPageSelect={() => {}}
+        />
+      )}
+    </PageSection>
+  );
 }
 
 export default function AddressesListPage() {

--- a/console/console-init/ui/src/Pages/AddressesListPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressesListPage.tsx
@@ -45,6 +45,9 @@ const retrun_ALL_ADDRESS_FOR_ADDRESS_SPACE = (
           }
         }
         Status {
+          PlanStatus{
+            Partitions
+          }
           IsReady
           Messages
         }
@@ -79,6 +82,9 @@ interface IAddressResponse {
         };
       };
       Status: {
+        PlanStatus:{
+          Partitions:number
+        }
         IsReady: boolean;
         Messages: Array<string>;
       };
@@ -168,7 +174,7 @@ function AddressesListFunction() {
     ),
     senders: getFilteredValue(address.Metrics, "enmasse-senders"),
     receivers: getFilteredValue(address.Metrics, "enmasse-receivers"),
-    shards: getFilteredValue(address.Metrics, "enmasse-shards"),
+    shards: address.Status.PlanStatus.Partitions,
     status: address.Status.IsReady ? "running" : "creating"
   }));
   // console.log(addresses);

--- a/console/console-init/ui/src/Pages/ConnectionDetailPage.tsx
+++ b/console/console-init/ui/src/Pages/ConnectionDetailPage.tsx
@@ -1,70 +1,163 @@
 import * as React from "react";
-import { ConnectionDetailHeader } from "src/Components/ConnectionDetail/ConnectionDetailHeader";
+import { ConnectionDetailHeader, IConnectionHeaderDetailProps } from "src/Components/ConnectionDetail/ConnectionDetailHeader";
 import { PageSection } from "@patternfly/react-core";
 import {
   ConnectionList,
   IConnection
 } from "src/Components/AddressSpace/ConnectionList";
+import gql from "graphql-tag";
+import { useQuery } from "@apollo/react-hooks";
+import { useParams } from "react-router";
+import { Loading } from "use-patternfly";
+import { IMetrics } from "./AddressesListPage";
+import { ILink, LinkList } from "src/Components/LinkList";
+
+interface IConnectionDetailResponse {
+  connections: {
+    Total: number;
+    Connections: Array<{
+      ObjectMeta: {
+        Name: string;
+        Namespace: string;
+        CreationTimeStamp: string;
+        ResourceVersion:string;
+      };
+      Spec: {
+        Hostname:string,
+        ContainerId:string,
+        Protocol:string,
+      };
+      Metrics:Array<{
+        Name:string,
+        Type:string,
+        Value:number,
+        Units:string,
+      }>;
+      Links:{
+        Total:number;
+        Links:Array<{
+          ObjectMeta:{
+            Name:string;
+            Namespace:string;
+          };
+          Spec: {
+            Role:string;
+          };
+          Metrics:Array<{
+            Name:string;
+            Type:string;
+            Value:number;
+            Units:string;
+          }>;
+        }>;
+      }
+    }>;
+  };
+}
+const return_CONNECTION_DETAIL = (
+  addressSpaceName?: string,
+  addressSpaceNameSpcae?: string,
+  connectionName?: string
+) => {
+  const CONNECTION_DETAIL = gql`
+  query single_connections {
+    connections(
+      filter: "\`$.Spec.AddressSpace.ObjectMeta.Name\` = '${addressSpaceName}' AND \`$.Spec.AddressSpace.ObjectMeta.Namespace\` = '${addressSpaceNameSpcae}' AND \`$.ObjectMeta.Name\` = '${connectionName}'"
+    ) {
+      Total
+      Connections {
+        ObjectMeta {
+          Name
+          Namespace
+          CreationTimestamp
+          ResourceVersion
+        }
+        Spec {
+          Hostname
+          ContainerId
+          Protocol
+        }
+        Metrics{
+          Name
+          Type
+          Value
+          Units
+        }
+        Links{
+          Total
+          Links{
+            ObjectMeta{
+              Name
+              Namespace
+            }
+            Spec {
+              Role
+            }
+            Metrics{
+              Name
+              Type
+              Value
+              Units
+            }
+          }
+        }
+      }
+    }
+  }
+  `;
+  return CONNECTION_DETAIL;
+};
+
+const getFilteredValue = (object: IMetrics[], value: string) => {
+  const filtered = object.filter(obj => obj.Name === value);
+  if (filtered.length > 0) {
+    return filtered[0].Value;
+  }
+  return 0;
+};
 
 export default function ConnectionDetailPage() {
-  const props = {
-    hostname: "1.219.2.1.33904",
-    containerId: "myapp1",
-    protocol: "AMQP",
-    product: "QpidJMS",
-    version: "0.31.0",
-    platform: "0.8.0_152.25.125.b16",
-    os: "Mac OS X 10.12.6,x86_64",
-    messagesIn: 0,
-    messagesOut: 0
+  const {name,namespace,connectionname,connectionnamespace} = useParams();
+  const{loading,data} = useQuery<IConnectionDetailResponse>(
+    return_CONNECTION_DETAIL(name||"",namespace||"",connectionname||""),
+    {pollInterval:5000}
+  )
+  if(loading) return <Loading/>
+  const { connections } = data || {
+    connections: { Total: 0, Connections: [] }
   };
-  const rows: IConnection[] = [
-    {
-      hostname: "foo",
-      containerId: "123",
-      protocol: "AMQP",
-      messagesIn: 123,
-      messagesOut: 123,
-      senders: 123,
-      receivers: 123,
-      status: "running"
-    },
-    {
-      hostname: "foo",
-      containerId: "123",
-      protocol: "AMQP",
-      messagesIn: 123,
-      messagesOut: 123,
-      senders: 123,
-      receivers: 123,
-      status: "running"
-    },
-    {
-      hostname: "foo",
-      containerId: "123",
-      protocol: "AMQP",
-      messagesIn: 123,
-      messagesOut: 123,
-      senders: 123,
-      receivers: 123,
-      status: "running"
-    }
-  ];
+  const connection = connections.Connections[0];
+  console.log(connection)
+  const connectionDetail:IConnectionHeaderDetailProps ={
+    hostname:connection.ObjectMeta.Name,
+    containerId:connection.ObjectMeta.Namespace,
+    version:connection.ObjectMeta.ResourceVersion,
+    protocol:connection.Spec.Protocol.toUpperCase(),
+    messagesIn:getFilteredValue(connection.Metrics, "enmasse_messages_in"),
+    messagesOut:getFilteredValue(connection.Metrics, "enmasse_messages_out"),
+    //Change
+    os:"Mac OS X 10.12.6,x86_64",
+    platform:connection.Spec.ContainerId,
+    //Change
+    product:"QpidJMS"
+  }
+
+  const linkRows:ILink[] = connection.Links.Links.map(link=>({
+    name:link.ObjectMeta.Name,
+    role:link.Spec.Role,
+    address:link.ObjectMeta.Namespace,
+    deliveries:getFilteredValue(link.Metrics,"enmasse_deliveries"),
+    rejected:getFilteredValue(link.Metrics,"enmasse_rejected"),
+    released:getFilteredValue(link.Metrics,"enmasse_released"),
+    modified:getFilteredValue(link.Metrics,"enmasse_modified"),
+    presettled:getFilteredValue(link.Metrics,"enmasse_presettled"),
+    undelivered:getFilteredValue(link.Metrics,"enmasse_undelivered"),
+  }));
   return (
     <>
-      <ConnectionDetailHeader
-        hostname={props.hostname}
-        containerId={props.containerId}
-        protocol={props.protocol}
-        product={props.product}
-        version={props.version}
-        platform={props.platform}
-        os={props.os}
-        messagesIn={props.messagesIn}
-        messagesOut={props.messagesOut}
-      />
+      <ConnectionDetailHeader {...connectionDetail}/>
       <PageSection>
-        <ConnectionList rows={rows} />
+        <LinkList rows={linkRows} />
       </PageSection>
     </>
   );

--- a/console/console-init/ui/src/Pages/IndexPage.tsx
+++ b/console/console-init/ui/src/Pages/IndexPage.tsx
@@ -11,6 +11,7 @@ import { EditAddress } from "../Pages/EditAddressPage";
 const addressRows: IAddress[] = [
   {
     name: 'foo',
+    namespace:"foo",
     type: 'Queue',
     plan: 'small',
     messagesIn: 123,
@@ -23,6 +24,7 @@ const addressRows: IAddress[] = [
   },
   {
     name: 'foo',
+    namespace:"foo",
     type: 'Queue',
     plan: 'small',
     messagesIn: 123,
@@ -35,6 +37,7 @@ const addressRows: IAddress[] = [
   },
   {
     name: 'foo',
+    namespace:"foo",
     type: 'Queue',
     plan: 'small',
     messagesIn: 123,

--- a/console/console-init/ui/src/stories/AddressList.stories.tsx
+++ b/console/console-init/ui/src/stories/AddressList.stories.tsx
@@ -13,6 +13,7 @@ export default {
 const rows: IAddress[] = [
   {
     name: "foo",
+    namespace:"foo",
     type: "Queue",
     plan: "small",
     messagesIn: 123,
@@ -25,6 +26,7 @@ const rows: IAddress[] = [
   },
   {
     name: "foo",
+    namespace:"foo",
     type: "Queue",
     plan: "small",
     messagesIn: 123,
@@ -37,6 +39,7 @@ const rows: IAddress[] = [
   },
   {
     name: "foo",
+    namespace:"foo",
     type: "Queue",
     plan: "small",
     messagesIn: 123,

--- a/console/console-init/ui/src/stories/AddressSpaceHeader.stories.tsx
+++ b/console/console-init/ui/src/stories/AddressSpaceHeader.stories.tsx
@@ -28,7 +28,6 @@ export const addressSpaceHeaderNavigation = () => {
     <MemoryRouter>
       <AddressSpaceNavigation
         activeItem={select("Active Nav Item", options, "addresses")}
-        onSelect={action("Nav Item selected")}
       />
     </MemoryRouter>
   );


### PR DESCRIPTION

### Description
- Rename Metadata to ObjectMeta
- Modify routes path for address and connection detail page
- add data for sender and receiver details in connection list page.