### PR TITLE
Fix: make EditAddress real-time

### DIFF
--- a/console/console-init/ui/src/Pages/AddressSpace/AddressListPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpace/AddressListPage.tsx
@@ -119,6 +119,7 @@ export const AddressListPage: React.FunctionComponent<IAddressListPageProps> = (
         }
       });
       setAddressBeingEdited(null);
+      refetch();
     }
   };
   const handleEditChange = (address: IAddress) =>


### PR DESCRIPTION
The implementation had missed calling the refetch method owing to which there was a lag while displaying the addresslist. Now the entire list is re-fetched after a successful plan edit.