### PR TITLE
fix: refetch addressspace list after create

### DIFF
--- a/console/console-init/ui/src/Pages/AddressSpaceList/AddressSpaceListFilterPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceList/AddressSpaceListFilterPage.tsx
@@ -40,6 +40,7 @@ interface IAddressSpaceListFilterPageProps {
   filterType?: string | null;
   setFilterType: (value: string | null) => void;
   totalAddressSpaces: number;
+  setOnCreationRefetch?: (value: boolean) => void;
 }
 export const AddressSpaceListFilterPage: React.FunctionComponent<IAddressSpaceListFilterPageProps> = ({
   filterValue,
@@ -50,7 +51,8 @@ export const AddressSpaceListFilterPage: React.FunctionComponent<IAddressSpaceLi
   setFilterNamespaces,
   filterType,
   setFilterType,
-  totalAddressSpaces
+  totalAddressSpaces,
+  setOnCreationRefetch
 }) => {
   const [isCreateWizardOpen, setIsCreateWizardOpen] = React.useState(false);
   const onClearAllFilters = () => {
@@ -80,6 +82,7 @@ export const AddressSpaceListFilterPage: React.FunctionComponent<IAddressSpaceLi
           <CreateAddressSpace
             isCreateWizardOpen={isCreateWizardOpen}
             setIsCreateWizardOpen={setIsCreateWizardOpen}
+            setOnCreationRefetch={setOnCreationRefetch}
           />
         )}
       </DataToolbarItem>

--- a/console/console-init/ui/src/Pages/AddressSpaceList/AddressSpaceListPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceList/AddressSpaceListPage.tsx
@@ -25,6 +25,8 @@ interface AddressSpaceListPageProps {
   filter_Names: string[];
   filter_NameSpace: string[];
   filter_Type: string | null;
+  onCreationRefetch?: boolean;
+  setOnCreationRefetch: (value: boolean) => void;
 }
 export const AddressSpaceListPage: React.FunctionComponent<AddressSpaceListPageProps> = ({
   page,
@@ -33,7 +35,9 @@ export const AddressSpaceListPage: React.FunctionComponent<AddressSpaceListPageP
   setTotalAddressSpaces,
   filter_Names,
   filter_NameSpace,
-  filter_Type
+  filter_Type,
+  onCreationRefetch,
+  setOnCreationRefetch
 }) => {
   useDocumentTitle("Addressspace List");
   useA11yRouteChange();
@@ -61,6 +65,10 @@ export const AddressSpaceListPage: React.FunctionComponent<AddressSpaceListPageP
     { pollInterval: 20000, fetchPolicy: "network-only" }
   );
   // console.log(data);
+  if(onCreationRefetch){
+    refetch();
+    setOnCreationRefetch(false);
+  }
   const handleCancelEdit = () => setAddressSpaceBeingEdited(null);
   const handleSaving = async () => {
     addressSpaceBeingEdited && await client.mutate({

--- a/console/console-init/ui/src/Pages/AddressSpaceList/AddressSpaceListWithFilterAndPaginationPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceList/AddressSpaceListWithFilterAndPaginationPage.tsx
@@ -17,6 +17,7 @@ export default function AddressSpaceListWithFilterAndPagination() {
   useA11yRouteChange();
   const [filterValue, setFilterValue] = React.useState<string | null>("Name");
   const [filterNames, setFilterNames] = React.useState<string[]>([]);
+  const [onCreationRefetch, setOnCreationRefetch] = React.useState<boolean>(false);
   const [filterNamespaces, setFilterNamespaces] = React.useState<string[]>([]);
   const [filterType, setFilterType] = React.useState<string | null>(null);
   const [totalAddressSpaces, setTotalAddressSpaces] = React.useState<number>(0);
@@ -80,6 +81,7 @@ export default function AddressSpaceListWithFilterAndPagination() {
             filterType={filterType}
             setFilterType={setFilterType}
             totalAddressSpaces={totalAddressSpaces}
+            setOnCreationRefetch={setOnCreationRefetch}
           />
         </GridItem>
         <GridItem span={5}>
@@ -95,6 +97,8 @@ export default function AddressSpaceListWithFilterAndPagination() {
         filter_Names={filterNames}
         filter_NameSpace={filterNamespaces}
         filter_Type={filterType}
+        onCreationRefetch={onCreationRefetch}
+        setOnCreationRefetch={setOnCreationRefetch}
       />
       {totalAddressSpaces > 0 && renderPagination(page, perPage)}
     </PageSection>

--- a/console/console-init/ui/src/Pages/CreateAddressSpace/CreateAddressSpacePage.tsx
+++ b/console/console-init/ui/src/Pages/CreateAddressSpace/CreateAddressSpacePage.tsx
@@ -14,11 +14,13 @@ interface ICreateAddressSpaceProps {
 interface ICreateAddressSpaceProps {
   isCreateWizardOpen: boolean;
   setIsCreateWizardOpen: (value: boolean) => void;
+  setOnCreationRefetch?: (value: boolean) => void;
 }
 export const CreateAddressSpace: React.FunctionComponent<ICreateAddressSpaceProps> = ({
   isCreateWizardOpen,
   setIsCreateWizardOpen,
-  refetch
+  refetch,
+  setOnCreationRefetch
 }) => {
   const [addressSpaceName, setAddressSpaceName] = React.useState("");
   const [addressSpaceType, setAddressSpaceType] = React.useState(" ");
@@ -58,6 +60,8 @@ export const CreateAddressSpace: React.FunctionComponent<ICreateAddressSpaceProp
         setAddressSpaceName("");
         setNamespace("");
         setAuthenticationService("");
+
+        if (setOnCreationRefetch) setOnCreationRefetch(true);
       }
       if (refetch) refetch();
     }


### PR DESCRIPTION
The address space list is now being refreshed after a successful creation of a new instance.