### PR TITLE
fix build and expose graphql backend via oauth-proxy

### DIFF
--- a/console/console-init/oauth-proxy/cfg/oauth-proxy-kubernetes.cfg
+++ b/console/console-init/oauth-proxy/cfg/oauth-proxy-kubernetes.cfg
@@ -14,8 +14,7 @@ tls_cert_file = "/etc/tls/private/tls.crt"
 tls_key_file = "/etc/tls/private/tls.key"
 
 upstreams = [
-    "https://kubernetes.default.svc/apis/",
-    "https://kubernetes.default.svc/api/",
+    "http://127.0.0.1:9090/graphql/",
     "file:/apps/www/#/",
 ]
 

--- a/console/console-init/oauth-proxy/cfg/oauth-proxy-openshift.cfg
+++ b/console/console-init/oauth-proxy/cfg/oauth-proxy-openshift.cfg
@@ -19,8 +19,7 @@ tls_key_file = "/etc/tls/private/tls.key"
 #    "file:/apps/www/#/",
 #]
 upstreams = [
-    "http://127.0.0.1:8080/apis/",
-    "http://127.0.0.1:8080/api/",
+    "http://127.0.0.1:9090/graphql/",
     "file:/apps/www/#/",
 ]
 

--- a/console/console-init/src/assembly/unix-dist.xml
+++ b/console/console-init/src/assembly/unix-dist.xml
@@ -27,7 +27,7 @@
     <includeBaseDirectory>False</includeBaseDirectory>
     <fileSets>
         <fileSet>
-           <directory>${project.basedir}/ui/dist</directory>
+           <directory>${project.basedir}/ui/build</directory>
             <outputDirectory>/oauth-proxy/www</outputDirectory>
             <includes>
                 <include>**</include>


### PR DESCRIPTION
Adapts the existing Make build to include the new UIs artefacts in the console-init image.