### PR TITLE
Make graphql endpoint injectable from the build

### DIFF
--- a/console/console-init/pom.xml
+++ b/console/console-init/pom.xml
@@ -67,6 +67,7 @@
                 <REACT_APP_VERSION>${project.version}</REACT_APP_VERSION>
                 <REACT_APP_NAME>EnMasse Console</REACT_APP_NAME>
                 <REACT_APP_DOCS>${application.docs}</REACT_APP_DOCS>
+                <REACT_APP_GRAPHQL_ENDPOINT>/graphql/query</REACT_APP_GRAPHQL_ENDPOINT>
               </environmentVariables>
               <arguments>run-script build</arguments>
             </configuration>

--- a/console/console-init/ui/src/App.tsx
+++ b/console/console-init/ui/src/App.tsx
@@ -11,8 +11,9 @@ import ApolloClient from "apollo-boost";
 import { ApolloProvider } from "@apollo/react-hooks";
 import avatarImg from "./img_avatar.svg";
 
+const graphqlEndpoint = process.env.REACT_APP_GRAPHQL_ENDPOINT ? process.env.REACT_APP_GRAPHQL_ENDPOINT : "http://localhost:4000";
 const client = new ApolloClient({
-  uri: "http://localhost:4000"
+  uri: graphqlEndpoint
 });
 
 const avatar = (


### PR DESCRIPTION
Makes GraphQL endpoint injectable from the build in order that we can inject the backend's true url `/graphql/query`.

@anukritijha @drcoolsanjeev is there a neater way?