### PR TITLE
Fix inconsistency in naming of metrics (- vs _)

### DIFF
--- a/console/console-init/ui/mock-console-server/mock-console-server.js
+++ b/console/console-init/ui/mock-console-server/mock-console-server.js
@@ -872,13 +872,13 @@ function makeMockAddressMetrics() {
       Units: "messages"
     },
     {
-      Name: "enmasse-senders",
+      Name: "enmasse_senders",
       Type: "gauge",
       Value: Math.floor(Math.random() * 3),
       Units: "links"
     },
     {
-      Name: "enmasse-receivers",
+      Name: "enmasse_receivers",
       Type: "gauge",
       Value: Math.floor(Math.random() * 3),
       Units: "links"
@@ -1008,13 +1008,13 @@ function makeAddressSpaceMetrics(as) {
 
   return [
     {
-      Name: "enmasse-connections",
+      Name: "enmasse_connections",
       Type: "gauge",
       Value: cons.length,
       Units: "connections"
     },
     {
-      Name: "enmasse-addresses",
+      Name: "enmasse_addresses",
       Type: "gauge",
       Value: addrs.length,
       Units: "addresses"

--- a/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
@@ -91,8 +91,8 @@ export const AddressListPage: React.FunctionComponent<IAddressListPageProps> = (
       address.Metrics,
       "enmasse_messages_stored"
     ),
-    senders: getFilteredValue(address.Metrics, "enmasse-senders"),
-    receivers: getFilteredValue(address.Metrics, "enmasse-receivers"),
+    senders: getFilteredValue(address.Metrics, "enmasse_senders"),
+    receivers: getFilteredValue(address.Metrics, "enmasse_receivers"),
     shards: address.Status.PlanStatus.Partitions,
     isReady: address.Status.IsReady,
     status: address.Status.Phase,


### PR DESCRIPTION
There was inconsisency in the mock's metric names.  This change resolves it and fixes up the uses in the .tsxs.