### PR TITLE
Added authentication services to the mock

### DIFF
--- a/console/console-init/ui/mock-console-server/README.md
+++ b/console/console-init/ui/mock-console-server/README.md
@@ -263,6 +263,56 @@ query filtered_address_plans {
 }
 ```
 
+## all_authentication_services (from the address space schema)
+
+```
+query addressspace_schema {
+  addressSpaceSchema_v2  {
+    ObjectMeta {
+      Name
+    }
+    Spec {
+      AuthenticationServices
+    }
+  }
+}
+```
+
+## filtered_authentication_services
+
+schema authentication services can be filtered by address space type (from the address space schema)
+
+```
+query filtered_addressspace_schema($t:AddressSpaceType = standard){
+  addressSpaceSchema_v2(addressSpaceType:$t)  {
+    ObjectMeta {
+      Name
+    }
+    Spec {
+      AuthenticationServices
+    }
+  }
+}
+```
+
+## all_authentication_services
+
+all unvalidated authentication services
+
+```
+query authentication_services {
+  authenticationServices{
+    Spec
+    {
+      Type
+    }
+    ObjectMeta {
+      Name
+    }
+  }
+}
+
+```
 
 ## all_link_names_for_connection
 

--- a/console/console-init/ui/mock-console-server/mock-console-server.js
+++ b/console/console-init/ui/mock-console-server/mock-console-server.js
@@ -155,6 +155,47 @@ const availableAddressTypes = [
   },
 ];
 
+const availableAuthenticationServices = [
+  createAuthenticationService("none", "none-authservice"),
+  createAuthenticationService("standard", "standard-authservice")
+];
+
+function createAuthenticationService(type, name) {
+  return {
+    Spec: {
+      Type: type
+    },
+    ObjectMeta: {
+      Name: name,
+      Uid: uuidv1(),
+      CreationTimestamp: getRandomCreationDate()
+    }
+  };
+}
+
+const availableAddressSpaceSchemas = [
+  {
+    ObjectMeta: {
+      Name: "brokered"
+    },
+    Spec: {
+      AuthenticationServices: ["none-authservice", "standard-authservice"],
+      Description:
+        "A brokered address space consists of a broker combined with a console for managing addresses."
+    }
+  },
+  {
+    ObjectMeta: {
+      Name: "standard"
+    },
+    Spec: {
+      AuthenticationServices: ["none-authservice", "standard-authservice"],
+      Description:
+        "A standard address space consists of an AMQP router network in combination with attachable 'storage units'. The implementation of a storage unit is hidden from the client and the routers with a well defined API."
+    }
+  }
+];
+
 const availableNamespaces = [
   {
     ObjectMeta: {
@@ -1106,6 +1147,16 @@ EOF
     },
 
     namespaces: () => availableNamespaces,
+
+    authenticationServices: () => availableAuthenticationServices,
+    addressSpaceSchema: () => availableAddressSpaceSchemas,
+    addressSpaceSchema_v2: (parent, args, context, info) => {
+      return availableAddressSpaceSchemas.filter(
+        o =>
+          args.addressSpaceType === undefined ||
+          o.ObjectMeta.Name === args.addressSpaceType
+      );
+    },
 
     addressTypes: () => (['queue', 'topic', 'subscription', 'multicast', 'anycast']),
     addressTypes_v2: (parent, args, context, info) => {

--- a/console/console-init/ui/mock-console-server/schema.js
+++ b/console/console-init/ui/mock-console-server/schema.js
@@ -283,7 +283,7 @@ const typeDefs = gql`
         authenticationServices: [AuthenticationService_admin_enmasse_io_v1beta1!]!
         "Returns the addressSpaceSchema"
         addressSpaceSchema: [AddressSpaceSchema_enmasse_io_v1beta1!]!
-        "Returns the addressSpaceSchema optionally filtering those for a matching address space plan and/or address type"
+        "Returns the addressSpaceSchema optionally filtering those for a matching address space type"
         addressSpaceSchema_v2(
           addressSpaceType: AddressSpaceType
         ): [AddressSpaceSchema_enmasse_io_v1beta1!]!

--- a/console/console-init/ui/mock-console-server/schema.js
+++ b/console/console-init/ui/mock-console-server/schema.js
@@ -21,6 +21,11 @@ const typeDefs = gql`
         anycast
     }
 
+    enum AuthenticationServiceType {
+        none
+        standard
+    }
+
     enum LinkRole {
         sender,
         receiver
@@ -67,6 +72,27 @@ const typeDefs = gql`
         LongDescription: String!
         ShortDescription: String!
         DisplayOrder: Int!
+    }
+
+    type AuthenticationService_admin_enmasse_io_v1beta1 {
+        ObjectMeta: ObjectMeta_v1!
+        Spec: AuthenticationServiceSpec_admin_enmasse_io_v1beta1!
+        Status: AuthenticationServiceStatus_admin_enmasse_io_v1beta1!
+    }
+    type AuthenticationServiceStatus_admin_enmasse_io_v1beta1 {
+        host: String!
+        port: Int!
+    }
+    type AuthenticationServiceSpec_admin_enmasse_io_v1beta1 {
+        Type: AuthenticationServiceType!
+    }
+    type AddressSpaceSchema_enmasse_io_v1beta1 {
+        ObjectMeta: ObjectMeta_v1!
+        Spec: AddressSpaceSchemaSpec_enmasse_io_v1beta1!
+    }
+    type AddressSpaceSchemaSpec_enmasse_io_v1beta1 {
+        AuthenticationServices: [String!]
+        Description: String
     }
 
     type Connection_consoleapi_enmasse_io_v1beta1 {
@@ -252,6 +278,15 @@ const typeDefs = gql`
 
         "Returns the address plans defined by the system optionally filtering those for a matching address space plan and/or address type"
         addressPlans(addressSpacePlan: String, addressType: AddressType): [AddressPlan_admin_enmasse_io_v1beta2!]!
+
+        "Returns the authenticationServices"
+        authenticationServices: [AuthenticationService_admin_enmasse_io_v1beta1!]!
+        "Returns the addressSpaceSchema"
+        addressSpaceSchema: [AddressSpaceSchema_enmasse_io_v1beta1!]!
+        "Returns the addressSpaceSchema optionally filtering those for a matching address space plan and/or address type"
+        addressSpaceSchema_v2(
+          addressSpaceType: AddressSpaceType
+        ): [AddressSpaceSchema_enmasse_io_v1beta1!]!
 
         "Returns the current logged on user"
         whoami: User_v1!


### PR DESCRIPTION
It is best to get them from the addressSpaceSchema definition.

Created new queries for:
- addressSpaceSchema
- authenticationServices

Signed-off-by: Vanessa <vbusch@redhat.com>

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
